### PR TITLE
perf: apply React best practices optimizations

### DIFF
--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -1,8 +1,8 @@
 "use client";
 import { lazy, Suspense, useCallback, useMemo } from "react";
+import nextDynamic from "next/dynamic";
 import Image from "next/image";
 import type { TeamsData } from "@/types";
-import { AnimatePresence, motion } from "framer-motion";
 import { useNavigation } from "@/hooks/useNavigation";
 import { useTeamGeneration } from "@/hooks/useTeamGeneration";
 import { useKeyboardShortcuts, useGlobalKeyboardShortcuts } from "@/hooks/useKeyboardShortcuts";
@@ -16,6 +16,9 @@ import { PositionSelectionSkeleton } from "@/components/ui/PositionSelectionSkel
 import { StepIndicator } from "@/components/ui/StepIndicator";
 import { ArrowLeft } from "lucide-react";
 import { Button } from "@/components/ui/button";
+
+const MotionDiv = nextDynamic(() => import("framer-motion").then(mod => mod.motion.div), { ssr: false });
+const AnimatePresence = nextDynamic(() => import("framer-motion").then(mod => mod.AnimatePresence), { ssr: false });
 
 // Lazy loading de componentes
 const PlayerForm = lazy(() => import("@/components/PlayerForm"));
@@ -157,7 +160,7 @@ export default function Home() {
       <ToastProvider>
         <div className="min-h-screen flex flex-col items-center justify-start p-4 pt-8">
         <div className="w-full max-w-4xl mx-auto">
-          <motion.div
+          <MotionDiv
             initial={{ opacity: 0, y: -20 }}
             animate={{ opacity: 1, y: 0 }}
             className="text-center mb-8"
@@ -189,10 +192,10 @@ export default function Home() {
                 <div className="w-8"></div>
               </div>
             )}
-          </motion.div>
+          </MotionDiv>
 
           <AnimatePresence mode="wait">
-            <motion.div
+            <MotionDiv
               key={step}
               initial={{ opacity: 0, x: -50 }}
               animate={{ opacity: 1, x: 0 }}
@@ -200,7 +203,7 @@ export default function Home() {
               transition={{ duration: 0.3 }}
             >
               {renderCurrentStep}
-            </motion.div>
+            </MotionDiv>
           </AnimatePresence>
         </div>
         </div>

--- a/src/hooks/useKeyboardShortcuts.ts
+++ b/src/hooks/useKeyboardShortcuts.ts
@@ -1,5 +1,5 @@
 "use client";
-import { useEffect, useCallback } from "react";
+import { useEffect, useCallback, useRef } from "react";
 
 interface KeyboardShortcut {
   key: string;
@@ -11,8 +11,10 @@ interface KeyboardShortcut {
 }
 
 export function useKeyboardShortcuts(shortcuts: KeyboardShortcut[]) {
+  const shortcutsRef = useRef(shortcuts);
+  shortcutsRef.current = shortcuts;
+
   const handleKeyPress = useCallback((event: KeyboardEvent) => {
-    // Don't trigger shortcuts when user is typing in form fields
     if (
       event.target instanceof HTMLInputElement ||
       event.target instanceof HTMLTextAreaElement ||
@@ -22,7 +24,7 @@ export function useKeyboardShortcuts(shortcuts: KeyboardShortcut[]) {
       return;
     }
 
-    const shortcut = shortcuts.find((s) => {
+    const shortcut = shortcutsRef.current.find((s) => {
       return (
         s.key.toLowerCase() === event.key.toLowerCase() &&
         (s.ctrlKey ?? false) === (event.ctrlKey || event.metaKey) &&
@@ -35,7 +37,7 @@ export function useKeyboardShortcuts(shortcuts: KeyboardShortcut[]) {
       event.preventDefault();
       shortcut.action();
     }
-  }, [shortcuts]);
+  }, []);
 
   useEffect(() => {
     document.addEventListener("keydown", handleKeyPress);

--- a/src/hooks/useTeamGeneration.ts
+++ b/src/hooks/useTeamGeneration.ts
@@ -7,7 +7,6 @@ export function useTeamGeneration() {
   const [teamTwo, setTeamTwo] = useState<PlayerWithPosition[]>([]);
 
   const generateBalancedTeams = (players: PlayerWithPosition[]) => {
-    // Use Fisher-Yates shuffle for better randomization
     const shuffledPlayers = [...players];
     for (let i = shuffledPlayers.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
@@ -17,39 +16,40 @@ export function useTeamGeneration() {
       ];
     }
 
-    const goalkeepers = shuffledPlayers.filter(
-      (player) => player.position === "Arco"
-    );
-    const defenders = shuffledPlayers.filter(
-      (player) => player.position === "Def"
-    );
-    const midfielders = shuffledPlayers.filter(
-      (player) => player.position === "Medio"
-    );
-    const forwards = shuffledPlayers.filter(
-      (player) => player.position === "Del"
-    );
-    const regularPlayers = shuffledPlayers.filter(
-      (player) => player.position === "Jugador"
-    );
+    const grouped: Record<string, PlayerWithPosition[]> = {
+      Arco: [],
+      Def: [],
+      Medio: [],
+      Del: [],
+      Jugador: [],
+    };
+    for (let i = 0; i < shuffledPlayers.length; i++) {
+      const player = shuffledPlayers[i];
+      if (grouped[player.position]) {
+        grouped[player.position].push(player);
+      }
+    }
 
-    const positionOrder = ["Arco", "Def", "Medio", "Del", "Jugador"];
+    const positionRank: Record<string, number> = {
+      Arco: 0,
+      Def: 1,
+      Medio: 2,
+      Del: 3,
+      Jugador: 4,
+    };
     const comparePositions = (a: PlayerWithPosition, b: PlayerWithPosition) => {
-      return (
-        positionOrder.indexOf(a.position) - positionOrder.indexOf(b.position)
-      );
+      return (positionRank[a.position] ?? 5) - (positionRank[b.position] ?? 5);
     };
 
     const newTeamOne: PlayerWithPosition[] = [];
     const newTeamTwo: PlayerWithPosition[] = [];
 
-    // Distribute players evenly
     const allPlayers = [
-      ...goalkeepers,
-      ...defenders,
-      ...midfielders,
-      ...forwards,
-      ...regularPlayers,
+      ...grouped.Arco,
+      ...grouped.Def,
+      ...grouped.Medio,
+      ...grouped.Del,
+      ...grouped.Jugador,
     ];
     allPlayers.forEach((player, index) => {
       if (index % 2 === 0) {
@@ -59,7 +59,6 @@ export function useTeamGeneration() {
       }
     });
 
-    // Sort by position
     newTeamOne.sort(comparePositions);
     newTeamTwo.sort(comparePositions);
 
@@ -70,9 +69,8 @@ export function useTeamGeneration() {
   };
 
   const generateSimpleTeams = (playerNames: string[]) => {
-    const goalkeepers = playerNames.filter((name) => name.includes("🧤"));
+    const goalkeeperSet = new Set(playerNames.filter((name) => name.includes("🧤")));
     const otherPlayers = playerNames.filter((name) => !name.includes("🧤"));
-    // Use Fisher-Yates shuffle for better randomization
     const shuffledOtherPlayers = [...otherPlayers];
     for (let i = shuffledOtherPlayers.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
@@ -82,9 +80,10 @@ export function useTeamGeneration() {
       ];
     }
 
-    let teamOneNames = [];
-    let teamTwoNames = [];
+    let teamOneNames: string[] = [];
+    let teamTwoNames: string[] = [];
 
+    const goalkeepers = Array.from(goalkeeperSet);
     if (goalkeepers.length === 2) {
       teamOneNames.push(goalkeepers[0]);
       teamTwoNames.push(goalkeepers[1]);
@@ -100,14 +99,14 @@ export function useTeamGeneration() {
     const teamOneWithPositions: PlayerWithPosition[] = teamOneNames.map(
       (name) => ({
         name,
-        position: name.includes("🧤") ? "Arco" : "Jugador",
+        position: goalkeeperSet.has(name) ? "Arco" : "Jugador",
       })
     );
 
     const teamTwoWithPositions: PlayerWithPosition[] = teamTwoNames.map(
       (name) => ({
         name,
-        position: name.includes("🧤") ? "Arco" : "Jugador",
+        position: goalkeeperSet.has(name) ? "Arco" : "Jugador",
       })
     );
 

--- a/src/store/teamStore.ts
+++ b/src/store/teamStore.ts
@@ -71,28 +71,40 @@ export const useTeamStore = create<TeamState>()(
           const allPlayers = [...teamsData.teamOne, ...teamsData.teamTwo]
           const shuffledPlayers = shuffle([...allPlayers])
 
-          // Group by positions
-          const goalkeepers = shuffledPlayers.filter(p => p.position === 'Arco')
-          const defenders = shuffledPlayers.filter(p => p.position === 'Def')
-          const midfielders = shuffledPlayers.filter(p => p.position === 'Medio')
-          const forwards = shuffledPlayers.filter(p => p.position === 'Del')
-          const players = shuffledPlayers.filter(p => p.position === 'Jugador')
+          const grouped: Record<string, PlayerWithPosition[]> = {
+            Arco: [],
+            Def: [],
+            Medio: [],
+            Del: [],
+            Jugador: [],
+          }
+          for (let i = 0; i < shuffledPlayers.length; i++) {
+            const player = shuffledPlayers[i]
+            if (grouped[player.position]) {
+              grouped[player.position].push(player)
+            }
+          }
 
-          const positionOrder = ['Arco', 'Def', 'Medio', 'Del', 'Jugador']
+          const positionRank: Record<string, number> = {
+            Arco: 0,
+            Def: 1,
+            Medio: 2,
+            Del: 3,
+            Jugador: 4,
+          }
           const comparePositions = (a: PlayerWithPosition, b: PlayerWithPosition) => {
-            return positionOrder.indexOf(a.position) - positionOrder.indexOf(b.position)
+            return (positionRank[a.position] ?? 5) - (positionRank[b.position] ?? 5)
           }
 
           const newTeamOne: PlayerWithPosition[] = []
           const newTeamTwo: PlayerWithPosition[] = []
 
-          // Distribute players alternately
           const allPlayersOrdered = [
-            ...goalkeepers,
-            ...defenders,
-            ...midfielders,
-            ...forwards,
-            ...players,
+            ...grouped.Arco,
+            ...grouped.Def,
+            ...grouped.Medio,
+            ...grouped.Del,
+            ...grouped.Jugador,
           ]
 
           allPlayersOrdered.forEach((player, index) => {
@@ -100,7 +112,6 @@ export const useTeamStore = create<TeamState>()(
             else newTeamTwo.push(player)
           })
 
-          // Sort teams by position
           newTeamOne.sort(comparePositions)
           newTeamTwo.sort(comparePositions)
 
@@ -139,9 +150,15 @@ export const useTeamStore = create<TeamState>()(
           }
 
           // Sort teams by position after swap
-          const positionOrder = ['Arco', 'Def', 'Medio', 'Del', 'Jugador']
+          const positionRank: Record<string, number> = {
+            Arco: 0,
+            Def: 1,
+            Medio: 2,
+            Del: 3,
+            Jugador: 4,
+          }
           const comparePositions = (a: PlayerWithPosition, b: PlayerWithPosition) => {
-            return positionOrder.indexOf(a.position) - positionOrder.indexOf(b.position)
+            return (positionRank[a.position] ?? 5) - (positionRank[b.position] ?? 5)
           }
 
           newTeamOne.sort(comparePositions)


### PR DESCRIPTION
- Lazy load framer-motion to reduce initial bundle size
- Combine filter iterations into single pass (teamStore, useTeamGeneration)
- Use object lookup instead of indexOf for O(1) performance
- Use Set for goalkeeper detection to avoid repeated includes()
- Optimize keyboard shortcuts hook with useRef to prevent re-attaching listeners